### PR TITLE
Endpoint to fetch all users who have signed the waiver

### DIFF
--- a/app/server/controllers/UserController.js
+++ b/app/server/controllers/UserController.js
@@ -212,6 +212,22 @@ UserController.getAll = function(callback) {
 };
 
 /**
+ * Get all users who have signed the waivers
+ * @param {Function} callback arg(err, users)
+ */
+UserController.getAllWithSignedWaviers = function(callback) {
+  User.find({
+    "confirmation.signatureLiability": { $exists: true, $ne: "" }
+  }).exec(function(err, users) {
+    if (err || !users) {
+      return callback(err);
+    }
+    console.log(users);
+    return callback(null, { users });
+  });
+};
+
+/**
  * Get a page of users.
  * @param  {[type]}   page     page number
  * @param  {[type]}   size     size of the page

--- a/app/server/routes/api.js
+++ b/app/server/routes/api.js
@@ -5,6 +5,8 @@ var request = require("request");
 jwt = require("jsonwebtoken");
 JWT_SECRET = process.env.JWT_SECRET;
 
+ADMIN_OAUTH_TOKEN = process.env.ADMIN_OAUTH_TOKEN;
+
 var aws = require("aws-sdk");
 aws.config.update({
   region: "us-west-1",
@@ -41,6 +43,10 @@ module.exports = function(router) {
    */
   function isAdmin(req, res, next) {
     var token = getToken(req);
+
+    if (token == ADMIN_OAUTH_TOKEN) {
+      return next();
+    }
 
     UserController.getByToken(token, function(err, user) {
       if (err) {
@@ -153,6 +159,15 @@ module.exports = function(router) {
     } else {
       UserController.getAll(defaultResponse(req, res));
     }
+  });
+
+  /**
+   * [ADMIN ONLY]
+   *
+   * GET - Get all users who have signed the waiver
+   */
+  router.get("/users/signedWaiver", isAdmin, function(req, res) {
+    UserController.getAllWithSignedWaviers(defaultResponse(req, res));
   });
 
   /**


### PR DESCRIPTION
Admins can now query `/users/signedWaiver` to fetch all of the users who have signed the waiver.

In addition, a secret was added to .env called `ADMIN_OAUTH_TOKEN` that provides admin access for the slack bot