### PR TITLE
Add PeterPortal API to StarterPacks page

### DIFF
--- a/app/client/src/assets/data/starter-pack-info.js
+++ b/app/client/src/assets/data/starter-pack-info.js
@@ -166,6 +166,12 @@ let starterPackData = [
             </p>
           </>
         )
+      },
+      {
+        name: "PeterPortal - An Unofficial API for UCI",
+        link: "https://api.peterportal.org/",
+        tooltip:
+          "PeterPortal API provides consolidated data about UCI professors, courses, and grades."
       }
     ]
   },


### PR DESCRIPTION
If it's not too late, can we get this on the starter pack page too? ICSSC has worked hard on this great resource for student devs.