### PR TITLE
Hide application due date on apply page

### DIFF
--- a/app/client/src/app/views/apply/apply.js
+++ b/app/client/src/app/views/apply/apply.js
@@ -107,9 +107,9 @@ export default function Apply(props) {
   return (
     <div className="hack-form-container">
       <h1>Apply</h1>
-      <div className="hack-disclaimer">
+      {/* <div className="hack-disclaimer">
         Applications are due January 30th 2022 @ 11:59 PM PST{" "}
-      </div>
+      </div> */}
       <Form className="hack-form">
         <PersonalInfo
           values={values}


### PR DESCRIPTION
Currently the [apply page](https://hackuci.com/apply) says that apps were due 1/30. This hides that code until we have a new due date.

![image](https://user-images.githubusercontent.com/29494270/152120962-3c32ea61-5c8d-4bc2-ab42-d229fece361b.png)
