### PR TITLE
Add wave footer to resources page

### DIFF
--- a/app/client/src/app/components/index.js
+++ b/app/client/src/app/components/index.js
@@ -7,3 +7,4 @@ export { default as HackLogo } from "./hack-logo/hackLogo";
 export { default as Footer } from "./footer/footer";
 export { default as Tooltip } from "./tooltip/tooltip";
 export { default as SponsorLoginModal } from "./sponsor-login-modal/SponsorLoginModal";
+export { default as WaveFooter } from "./wave-footer/WaveFooter";

--- a/app/client/src/app/components/wave-footer/WaveFooter.js
+++ b/app/client/src/app/components/wave-footer/WaveFooter.js
@@ -1,0 +1,16 @@
+import React from "react";
+
+import topWave from "assets/images/site-2022/top white wave.png";
+
+import "./WaveFooter.scss";
+
+function WaveFooter() {
+  return (
+    <div className="wave-footer">
+      <img className="top-wave" src={topWave} alt="" />
+      <div className="wave-footer-body" />
+    </div>
+  );
+}
+
+export default WaveFooter;

--- a/app/client/src/app/components/wave-footer/WaveFooter.scss
+++ b/app/client/src/app/components/wave-footer/WaveFooter.scss
@@ -1,0 +1,11 @@
+@import "globals/hack-styles.scss";
+
+.wave-footer {
+  position: absolute;
+  bottom: 0;
+  width: calc(max(1280px, 100%));
+  .wave-footer-body {
+    min-height: 60vh;
+    background-color: $dark-blue;
+  }
+}

--- a/app/client/src/app/views/resources/resources.js
+++ b/app/client/src/app/views/resources/resources.js
@@ -2,7 +2,7 @@ import React from "react";
 
 import "./resources.scss";
 
-import { Tooltip } from "app/components";
+import { Tooltip, WaveFooter } from "app/components";
 import { starterPackData } from "assets/data/starter-pack-info.js";
 
 import ProjectIdeas from "./project-ideas/projectIdeas";
@@ -71,6 +71,7 @@ function Resources({ match }) {
             </div>
           );
         })}
+        <WaveFooter />
       </div>
     );
   }


### PR DESCRIPTION
Create `WaveFooter` component to use on pages with an empty wave block.
Application form components need to be refactored to add wave, so the wave footer was omitted for now.